### PR TITLE
As Sentinel doesn't support AUTH command (as of Redis 4.0.7), passwor…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,10 +11,10 @@ import (
 )
 
 var (
-	ListenAddress    = "127.0.0.1:6379"  // Redundis listen address
-	SentinelAddress  = "127.0.0.1:26379" // Address of sentinel node
-	SentinelPassword = ""                // Sentinel password
-	MonitorName      = "test"            // Name of sentinel monitor
+	ListenAddress   = "127.0.0.1:6379"  // Redundis listen address
+	SentinelAddress = "127.0.0.1:26379" // Address of sentinel node
+	MasterPassword  = ""                // Redis Master password
+	MonitorName     = "test"            // Name of sentinel monitor
 
 	masterWait   = 30
 	notReady     = 30
@@ -36,7 +36,7 @@ func init() {
 func AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&ListenAddress, "listen-address", "l", ListenAddress, "Redundis listen address")
 	cmd.Flags().StringVarP(&SentinelAddress, "sentinel-address", "s", SentinelAddress, "Address of sentinel node")
-	cmd.Flags().StringVarP(&SentinelPassword, "sentinel-password", "p", SentinelPassword, "Sentinel password")
+	cmd.Flags().StringVarP(&MasterPassword, "master-password", "p", MasterPassword, "Master password")
 	cmd.Flags().StringVarP(&MonitorName, "monitor-name", "m", MonitorName, "Name of sentinel monitor")
 
 	// timeouts
@@ -60,7 +60,7 @@ func ReadConfigFile(configFile string) error {
 	// Set defaults to whatever might be there already
 	viper.SetDefault("listen-address", ListenAddress)
 	viper.SetDefault("sentinel-address", SentinelAddress)
-	viper.SetDefault("sentinel-password", SentinelPassword)
+	viper.SetDefault("master-password", MasterPassword)
 	viper.SetDefault("monitor-name", MonitorName)
 	viper.SetDefault("master-wait", masterWait)
 	viper.SetDefault("ready-wait", notReady)
@@ -79,7 +79,7 @@ func ReadConfigFile(configFile string) error {
 	// Set values. Config file will override commandline
 	ListenAddress = viper.GetString("listen-address")
 	SentinelAddress = viper.GetString("sentinel-address")
-	SentinelPassword = viper.GetString("sentinel-password")
+	MasterPassword = viper.GetString("master-password")
 	MonitorName = viper.GetString("monitor-name")
 	TimeoutMasterWait = time.Duration(viper.GetInt("master-wait")) * time.Second
 	TimeoutNotReady = time.Duration(viper.GetInt("ready-wait")) * time.Second

--- a/core/redundis.go
+++ b/core/redundis.go
@@ -94,7 +94,7 @@ func updateMaster() error {
 	config.Log.Debug("Contacting sentinel for address of master...")
 
 	// connect to sentinel in order to query for the master address
-	r, err := redis.DialURL("redis://"+config.SentinelAddress, redis.DialConnectTimeout(config.TimeoutNotReady), redis.DialReadTimeout(config.TimeoutSentinelPoll), redis.DialPassword(config.SentinelPassword))
+	r, err := redis.DialURL("redis://"+config.SentinelAddress, redis.DialConnectTimeout(config.TimeoutNotReady), redis.DialReadTimeout(config.TimeoutSentinelPoll))
 	if err != nil {
 		return fmt.Errorf("Failed to reach sentinel - %v", err)
 	}
@@ -113,7 +113,7 @@ func updateMaster() error {
 	config.Log.Debug("Master address: '%v'", masterAddr)
 
 	// wait for redis to transition to master
-	if err = verifyMaster(masterAddr, config.SentinelPassword); err != nil {
+	if err = verifyMaster(masterAddr, config.MasterPassword); err != nil {
 		return fmt.Errorf("Could not verify master - %v", err)
 	}
 


### PR DESCRIPTION
Hi,

Context:  3 nodes under Debian Strech with backports (redis 4.0.7) with sentinel and redundis  and an application which need to connect to a Redis server (a master with slaves in replication mode/auto-failover).

With redis configured without requirepass there is no problem.

But with requirepass set up :

./redundis -m mymaster -p ********************************************
2018-04-19 12:32:08 [redundis] INFO  Listening on '127.0.0.1:6379'
2018-04-19 12:32:08 [redundis] INFO  Monitoring master...
2018-04-19 12:32:08 [redundis] ERROR Failed to update master - Failed to reach sentinel - ERR unknown command 'AUTH'

The "missing" AUTH command on sentinel is known: https://github.com/antirez/redis/issues/3279#issuecomment-230485169  , so connecting to sentinel with NOAUTH is actually mandatory. 

Sentinel could be fixed with https://github.com/antirez/redis/pull/3329 

Until it append, this is a little PR as AUTH must only be used for Master (not on Sentinel) and as a result argument --sentinel-password doesn't make send but --master-password does 